### PR TITLE
Fixed some issues with drag and drop tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Go to [legend](#legend-types-of-changes) for further information about the types
 
 - Added tooltips for drag and drop functionality (no file movement yet)
 
+### Fixed
+
+- Fixed some issues with drag and drop tooltips
+
 ### Changed
 
 - Changed some of the drag and drop related structure


### PR DESCRIPTION
This commit fixes some minor issues regarding the drag and drop tooltips. There is nothing breaking in this PR since no file movement is taking place yet.

I apologize for clearing the new PR template, @sven-seyfert I just needed to get this minor PR out so that we can have more users test the tooltips for drag and drop. I will review the new PR template later so that I understand it all.