### PR TITLE
Fixed a theme-related ListView glitch

### DIFF
--- a/src/main.au3
+++ b/src/main.au3
@@ -626,13 +626,15 @@ Func _loadingCallback($hSystem, $hView, $sRoot, $sFolder, $sSelected, $sPath, $b
 
 	If $bLoading Then
 		; add delay before changing cursor and clearing status item count
-		AdlibRegister("_ClearStatus", 250)
+		AdlibRegister("_ListViewLoadWait", 250)
 		Return
 	EndIf
 
 	If $bCursorOverride Then
 		; reset GUI cursor if it has been overridden
 		GUISetCursor($MCID_ARROW, 0, $g_hGUI)
+		GUISetCursor($MCID_ARROW, 0, _GUIFrame_GetHandle($iFrame_A, 2))
+		GUICtrlSetState($idListview, $GUI_SHOW)
 		$bCursorOverride = False
 	EndIf
 
@@ -640,17 +642,19 @@ Func _loadingCallback($hSystem, $hView, $sRoot, $sFolder, $sSelected, $sPath, $b
 	$bPathInputChanged = False
 EndFunc   ;==>_loadingCallback
 
-Func _ClearStatus()
+Func _ListViewLoadWait()
 	If $bLoadStatus Then
 		; override GUI with loading/waiting cursor on directories that are slower to load
 		$bCursorOverride = True
 		GUISetCursor($MCID_WAIT, 1, $g_hGUI)
+		GUISetCursor($MCID_WAIT, 1, _GUIFrame_GetHandle($iFrame_A, 2))
+		GUICtrlSetState($idListview, $GUI_HIDE)
 		; clear statusbar item count
 		$g_aText[0] = ""
 		_WinAPI_RedrawWindow($g_hStatus)
 	EndIf
-	AdlibUnRegister("_ClearStatus")
-EndFunc   ;==>_ClearStatus
+	AdlibUnRegister("_ListViewLoadWait")
+EndFunc   ;==>_ListViewLoadWait
 
 Func _folderCallback($hSystem, $sRoot, $sFolder, $sSelected)
 	Local Static $sFolderPrev = ""


### PR DESCRIPTION
## Description

There was a theme-related visual glitch that affected the ListView. It only occurred with slower loading directories such as System32 if the cursor was hovering over ListView during loading.

#### 🔗 Linked GitHub Issues

No related issue.

#### 📋 What is the current behavior?

Current behavior keeps the ListView visible during slow loading directories.

#### 🚀 What is the new behavior?

New behavior hides the ListView during slow loading directories which gives the impression that the ListView has been cleared faster and ensures that the "wait" cursor shows over the ListView child window frame as well as the rest of the GUI. This also fixes the visual glitch.

<br>

## Type of changes

- [x] 🪲 Bugfix (change which fixes an issue)
- [ ] ⭐ New Feature (change which adds functionality)
- [ ] 🔒 Security fix (change which improves security)
- [ ] 🔮 Code style update (formatting, renaming)
- [ ] 🔨 Refactoring (code optimization without functional change)
- [ ] 📚 Documentation (updates to README or docs)
- [ ] ⚙️ Build or CI related changes
- [ ] 🧿 Other type <!-- please describe -->

<br>

## Breaking changes 🔥

<!-- Does this PR introduce breaking changes to existing functionality? If yes, please describe what will break and what users need to do to adapt. -->

- [ ] Yes <!-- please describe -->
- [x] No

<br>

## How and where was this tested?

#### 🖥️ Describe where you tested your changes

*System:*

- [x] Windows 11 (x64)
- [ ] Windows 10 (x64)
- [ ] Windows 10 (x86)
- [ ] other Windows version
- [ ] other operating system

*Context:*

- [ ] in Browser \<name and version>
- [ ] with Go \<version>
- [ ] with Node.js \<version>
- [x] with AutoIt 3.3.18.0
- [ ] with .NET (C#) \<version>
- [ ] with ...

#### 🔬 Describe how you tested your changes

- [x] Manually tested in system and context shown above
- [ ] Ran automatic tests (unit tests, integration tests, etc.)
- [ ] Other ways <!-- please describe -->

<br>

## Checklist

- [x] I have read and understood the available contributing guidelines.
- [x] I have ensured my code follows the available code conventions.
- [x] I have reviewed my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] I have added/updated necessary tests to cover the changes (if applicable).
- [x] I have checked for potential security implications.

<br>

## Additional context

<!-- Add any other context about the problem or improvement here, if relevant. -->

#### Screenshots

<!-- If relevant, provide before/after comparisons or GIFs of UI changes. -->

#### Note to reviewers

<!-- Add any notes for reviewers here. -->
